### PR TITLE
chore: Correct JSON schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -57,7 +57,9 @@
         },
         "then": {
           "properties": {
-            "$ref": "https://raw.githubusercontent.com/roadrunner-server/memcached/refs/heads/master/schema.json"
+            "config": {
+              "$ref": "https://raw.githubusercontent.com/roadrunner-server/memcached/refs/heads/master/schema.json"
+            }
           }
         },
         "else": {
@@ -87,8 +89,19 @@
                 }
               }
             },
-            "then": true,
-            "else": false
+            "then": {
+              "required": [
+                "driver",
+                "config"
+              ],
+              "properties": {
+                "config": {
+                  "type": "object",
+                  "description": "The memory plugin does not support configuration, but requires an empty config object to be present due to parsing logic and the fact that memory has no global configuration to inherit from.",
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Enforce empty config for memory driver

# Reason for This PR

Correction of schema.

## Description of Changes

Invalid config for memcached
Make memory require empty config object

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
