### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/plugin.go
+++ b/plugin.go
@@ -81,6 +81,8 @@ func (p *Plugin) Serve() chan error {
 	// For this config we should have 3 constructors: memory, boltdb and memcached but 4 KVs: default, boltdb-south, boltdb-north and memcached
 	// when user requests, for example, boltdb-south, we should provide that particular pre-configured storage
 
+	ctx := context.Background()
+
 	for k, v := range p.cfg.Data {
 		// for example, if the key didn't properly format (yaml)
 		if v == nil {
@@ -89,52 +91,53 @@ func (p *Plugin) Serve() chan error {
 
 		// check type of the v
 		// should be a map[string]any
-		switch t := v.(type) {
-		// correct type
-		case map[string]any:
-			if _, ok := t[driver]; !ok {
-				errCh <- errors.E(op, errors.Errorf("could not find mandatory driver field in the %s storage", k))
-				return errCh
-			}
-		default:
+		t, ok := v.(map[string]any)
+		if !ok {
 			p.log.Warn("wrong type detected in the configuration, please, check yaml indentation")
 			continue
+		}
+
+		if _, ok := t[driver]; !ok {
+			errCh <- errors.E(op, errors.Errorf("could not find mandatory driver field in the %s storage", k))
+			return errCh
 		}
 
 		// config key for the particular sub-driver kv.memcached.config
 		configKey := fmt.Sprintf("%s.%s.%s", PluginName, k, cfg)
 		// at this point we know, that driver field present in the configuration
-		drName := v.(map[string]any)[driver]
-		ctx := context.Background()
+		drName := t[driver]
 
 		// driver name should be a string
-		if drStr, ok := drName.(string); ok {
-			switch {
-			// local configuration section key
-			case p.cfgPlugin.Has(configKey):
-				err := p.checkAndSaveStorage(ctx, drStr, k, configKey)
-				if err != nil {
-					errCh <- errors.E(op, err)
-					return errCh
-				}
-				// try global then
-			case p.cfgPlugin.Has(k):
-				err := p.checkAndSaveStorage(ctx, drStr, k, k)
-				if err != nil {
-					errCh <- errors.E(op, err)
-					return errCh
-				}
-			default:
-				p.log.Warn("can't find local or global configuration, this section will be skipped", "local", configKey, "global", k)
+		drStr, ok := drName.(string)
+		if !ok {
+			p.log.Warn("driver field is not a string, skipping storage", "storage", k, "driver_type", fmt.Sprintf("%T", drName))
+			continue
+		}
 
-				err := p.checkAndSaveStorage(ctx, drStr, k, "")
-				if err != nil {
-					errCh <- errors.E(op, err)
-					return errCh
-				}
+		switch {
+		// local configuration section key
+		case p.cfgPlugin.Has(configKey):
+			err := p.checkAndSaveStorage(ctx, drStr, k, configKey)
+			if err != nil {
+				errCh <- errors.E(op, err)
+				return errCh
+			}
+			// try global then
+		case p.cfgPlugin.Has(k):
+			err := p.checkAndSaveStorage(ctx, drStr, k, k)
+			if err != nil {
+				errCh <- errors.E(op, err)
+				return errCh
+			}
+		default:
+			p.log.Warn("can't find local or global configuration, this section will be skipped", "local", configKey, "global", k)
+
+			err := p.checkAndSaveStorage(ctx, drStr, k, "")
+			if err != nil {
+				errCh <- errors.E(op, err)
+				return errCh
 			}
 		}
-		continue
 	}
 
 	return errCh
@@ -170,13 +173,8 @@ func (p *Plugin) Stop(ctx context.Context) error {
 			p.storages[k].Stop(ctx)
 		}
 
-		for k := range p.storages {
-			delete(p.storages, k)
-		}
-
-		for k := range p.constructors {
-			delete(p.constructors, k)
-		}
+		clear(p.storages)
+		clear(p.constructors)
 		stopCh <- struct{}{}
 	}()
 

--- a/plugin.go
+++ b/plugin.go
@@ -93,7 +93,7 @@ func (p *Plugin) Serve() chan error {
 		// should be a map[string]any
 		t, ok := v.(map[string]any)
 		if !ok {
-			p.log.Warn("wrong type detected in the configuration, please, check yaml indentation")
+			p.log.Warn("wrong type detected in the configuration, please, check yaml indentation", "storage", k)
 			continue
 		}
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/roadrunner-server/boltdb/v6 v6.0.0-beta.4
 	github.com/roadrunner-server/config/v6 v6.0.0-beta.3
 	github.com/roadrunner-server/endure/v2 v2.6.2
+	github.com/roadrunner-server/errors v1.5.0
 	github.com/roadrunner-server/kv/v6 v6.0.0
 	github.com/roadrunner-server/logger/v6 v6.0.0-beta.3
 	github.com/roadrunner-server/memcached/v6 v6.0.0-beta.4
@@ -51,7 +52,6 @@ require (
 	github.com/redis/go-redis/extra/redisprometheus/v9 v9.19.0 // indirect
 	github.com/redis/go-redis/v9 v9.19.0 // indirect
 	github.com/roadrunner-server/api-plugins/v6 v6.0.0-beta.2 // indirect
-	github.com/roadrunner-server/errors v1.5.0 // indirect
 	github.com/roadrunner-server/tcplisten v1.5.2 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -124,6 +124,7 @@ go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=

--- a/tests/kv_api_test.go
+++ b/tests/kv_api_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const kvAPIAddr = "127.0.0.1:6001"
@@ -290,4 +291,60 @@ func TestKVGRPCApi(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, hasResp.GetItems())
+}
+
+// TestKVRPCExtra covers rpc.go paths the happy-path API tests miss: the two
+// lookupStorage error returns, and the MExpire/Clear handlers (only ever probed
+// via GET-405 elsewhere, which never reaches the handler). All subtests share a
+// single container.
+func TestKVRPCExtra(t *testing.T) {
+	stop := startKvAPIContainer(t)
+	defer stop()
+
+	client := newKvClient()
+	ctx := t.Context()
+
+	t.Run("UnknownStorageNotFound", func(t *testing.T) {
+		_, err := client.Has(ctx, connect.NewRequest(&kvV2.KvRequest{
+			Storage: "does-not-exist",
+			Items:   []*kvV2.KvItem{{Key: "k"}},
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+
+	t.Run("EmptyStorageInvalidArgument", func(t *testing.T) {
+		_, err := client.Has(ctx, connect.NewRequest(&kvV2.KvRequest{
+			Storage: "",
+			Items:   []*kvV2.KvItem{{Key: "k"}},
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("MExpireThenClear", func(t *testing.T) {
+		const store = "in-memory"
+
+		_, err := client.Set(ctx, connect.NewRequest(&kvV2.KvRequest{
+			Storage: store,
+			Items:   []*kvV2.KvItem{{Key: "exp", Value: []byte("v")}},
+		}))
+		require.NoError(t, err)
+
+		_, err = client.MExpire(ctx, connect.NewRequest(&kvV2.KvRequest{
+			Storage: store,
+			Items:   []*kvV2.KvItem{{Key: "exp", Ttl: durationpb.New(60 * time.Second)}},
+		}))
+		require.NoError(t, err)
+
+		_, err = client.Clear(ctx, connect.NewRequest(&kvV2.KvRequest{Storage: store}))
+		require.NoError(t, err)
+
+		resp, err := client.Has(ctx, connect.NewRequest(&kvV2.KvRequest{
+			Storage: store,
+			Items:   []*kvV2.KvItem{{Key: "exp"}},
+		}))
+		require.NoError(t, err)
+		require.Empty(t, resp.Msg.GetItems())
+	})
 }

--- a/tests/plugin_serve_test.go
+++ b/tests/plugin_serve_test.go
@@ -1,0 +1,201 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	rrerrors "github.com/roadrunner-server/errors"
+	"github.com/roadrunner-server/kv/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests drive the kv.Plugin directly (no Endure container) to cover the
+// configuration-validation branches of Serve()/Init() that the integration
+// tests never reach — they always feed well-formed config.
+
+// mockCfg satisfies kv.Configurer.
+type mockCfg struct {
+	data         map[string]any  // returned through UnmarshalKey
+	has          map[string]bool // drives Serve's local/global/default switch
+	unmarshalErr error           // when set, UnmarshalKey fails (Init error path)
+}
+
+func (c *mockCfg) UnmarshalKey(_ string, out any) error {
+	if c.unmarshalErr != nil {
+		return c.unmarshalErr
+	}
+	if p, ok := out.(*map[string]any); ok {
+		*p = c.data
+	}
+	return nil
+}
+
+func (c *mockCfg) Has(name string) bool { return c.has[name] }
+
+// capHandler is a slog.Handler that records emitted records so tests can assert
+// which warnings the plugin logged.
+type capHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capHandler) WithGroup(string) slog.Handler      { return h }
+
+// hasWarn reports whether a warn-level record whose message contains sub was emitted.
+func (h *capHandler) hasWarn(sub string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := range h.records {
+		if h.records[i].Level == slog.LevelWarn && strings.Contains(h.records[i].Message, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// mockLogger satisfies kv.Logger.
+type mockLogger struct{ h slog.Handler }
+
+func (l *mockLogger) NamedLogger(string) *slog.Logger { return slog.New(l.h) }
+
+// newServingPlugin returns an Init'd plugin backed by the given config data and
+// Has() answers. The "kv" section is always present so Init succeeds.
+func newServingPlugin(t *testing.T, data map[string]any, has map[string]bool) (*kv.Plugin, *capHandler) {
+	t.Helper()
+	if has == nil {
+		has = map[string]bool{}
+	}
+	has[kv.PluginName] = true
+
+	h := &capHandler{}
+	p := &kv.Plugin{}
+	require.NoError(t, p.Init(&mockCfg{data: data, has: has}, &mockLogger{h: h}))
+	return p, h
+}
+
+// serveErr reads the (buffered) Serve channel without blocking: an error means
+// Serve aborted, nil means every storage was processed (saved or skipped).
+func serveErr(errCh chan error) error {
+	select {
+	case e := <-errCh:
+		return e
+	default:
+		return nil
+	}
+}
+
+func TestPluginServeBranches(t *testing.T) {
+	cases := []struct {
+		name    string
+		data    map[string]any
+		has     map[string]bool
+		wantErr bool
+		errSub  string // expected substring of the error (when wantErr)
+		warnSub string // expected substring of a warn record (when non-empty)
+	}{
+		{
+			name: "nil value is skipped",
+			data: map[string]any{"s": nil},
+		},
+		{
+			name:    "non-map value warns and skips",
+			data:    map[string]any{"s": "not-a-map"},
+			warnSub: "wrong type detected",
+		},
+		{
+			name:    "missing driver field errors",
+			data:    map[string]any{"s": map[string]any{}},
+			wantErr: true,
+			errSub:  "could not find mandatory driver field",
+		},
+		{
+			// the branch added by this PR: a non-string driver is now logged and
+			// skipped instead of being silently ignored.
+			name:    "non-string driver warns and skips",
+			data:    map[string]any{"s": map[string]any{"driver": 123}},
+			warnSub: "driver field is not a string",
+		},
+		{
+			name:    "unknown driver via local config errors",
+			data:    map[string]any{"s": map[string]any{"driver": "nope"}},
+			has:     map[string]bool{"kv.s.config": true},
+			wantErr: true,
+			errSub:  "no such constructor",
+		},
+		{
+			name:    "unknown driver via global config errors",
+			data:    map[string]any{"s": map[string]any{"driver": "nope"}},
+			has:     map[string]bool{"s": true},
+			wantErr: true,
+			errSub:  "no such constructor",
+		},
+		{
+			name:    "unknown driver via default branch warns then errors",
+			data:    map[string]any{"s": map[string]any{"driver": "nope"}},
+			wantErr: true,
+			errSub:  "no such constructor",
+			warnSub: "can't find local or global",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, h := newServingPlugin(t, tc.data, tc.has)
+
+			err := serveErr(p.Serve())
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSub)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.warnSub != "" {
+				assert.Truef(t, h.hasWarn(tc.warnSub), "expected a warn record containing %q", tc.warnSub)
+			}
+		})
+	}
+}
+
+func TestPluginInitDisabled(t *testing.T) {
+	p := &kv.Plugin{}
+	err := p.Init(&mockCfg{has: map[string]bool{}}, &mockLogger{h: &capHandler{}})
+	require.Error(t, err)
+	assert.Truef(t, rrerrors.Is(rrerrors.Disabled, err), "expected Disabled kind, got %v", err)
+}
+
+func TestPluginInitUnmarshalError(t *testing.T) {
+	p := &kv.Plugin{}
+	err := p.Init(&mockCfg{
+		has:          map[string]bool{kv.PluginName: true},
+		unmarshalErr: errors.New("boom"),
+	}, &mockLogger{h: &capHandler{}})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "boom")
+}
+
+func TestPluginWeightName(t *testing.T) {
+	p := &kv.Plugin{}
+	assert.Equal(t, uint(10), p.Weight())
+	assert.Equal(t, "kv", p.Name())
+}
+
+func TestPluginStopNoStorages(t *testing.T) {
+	p, _ := newServingPlugin(t, map[string]any{}, nil)
+	require.NoError(t, p.Stop(t.Context()))
+}

--- a/tests/plugin_serve_test.go
+++ b/tests/plugin_serve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -60,12 +61,9 @@ func (h *capHandler) WithGroup(string) slog.Handler      { return h }
 func (h *capHandler) hasWarn(sub string) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	for i := range h.records {
-		if h.records[i].Level == slog.LevelWarn && strings.Contains(h.records[i].Message, sub) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(h.records, func(r slog.Record) bool {
+		return r.Level == slog.LevelWarn && strings.Contains(r.Message, sub)
+	})
 }
 
 // mockLogger satisfies kv.Logger.


### PR DESCRIPTION
## Applied fixes

**S – Simplify (3)**
- `plugin.go:107` — replaced `switch t := v.(type) { case map[string]any: ... }` + redundant `v.(map[string]any)` with a direct `t, ok := v.(map[string]any)` type assertion using the already-bound `t`
- `plugin.go:137` — removed dead bare `continue` at the end of the loop body (no-op)
- `plugin.go:173,177` — replaced two range-delete loops (`for k := range m { delete(m, k) }`) with `clear(p.storages)` / `clear(p.constructors)` (Go 1.21+)

**M – Modern Go (2)**
- `plugin.go:108` — hoisted `ctx := context.Background()` above the loop (was re-allocated on every iteration)
- `plugin.go:173` — same `clear()` change (overlaps with S above)

**R – Review / bug (1)**
- `plugin.go:111` — non-string `driver` field was silently ignored; now logs a structured warning with the storage name and actual type so misconfiguration is visible in the log

## Deps

`go get -u all && go mod tidy` on root module; `go mod tidy` on `tests/`; `go work sync`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage configuration validation with enhanced logging when invalid configurations are encountered.

* **Tests**
  * Expanded test coverage for KV API remote procedure calls and plugin configuration initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->